### PR TITLE
Merge merge-inputmanager into main

### DIFF
--- a/src/main/java/io/github/lucasstarsz/fastj/systems/input/InputManager.java
+++ b/src/main/java/io/github/lucasstarsz/fastj/systems/input/InputManager.java
@@ -9,9 +9,10 @@ import io.github.lucasstarsz.fastj.systems.input.mouse.MouseActionListener;
 import java.awt.event.InputEvent;
 import java.awt.event.KeyEvent;
 import java.awt.event.MouseEvent;
-import java.awt.event.MouseWheelEvent;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+import java.util.function.BiConsumer;
 
 /**
  * Class to manage user input and input event processing.
@@ -26,6 +27,67 @@ public class InputManager {
     private final List<InputEvent> receivedInputEvents;
     private final List<InputEvent> eventBacklog;
     private volatile boolean isProcessingEvents;
+
+    private static final Map<Integer, BiConsumer<MouseEvent, List<MouseActionListener>>> MouseActionProcessor = Map.of(
+            MouseEvent.MOUSE_PRESSED, (mouseEvent, mouseActionListeners) -> {
+                for (MouseActionListener mouseActionListener : mouseActionListeners) {
+                    mouseActionListener.onMousePressed(mouseEvent);
+                }
+            },
+            MouseEvent.MOUSE_RELEASED, (mouseEvent, mouseActionListeners) -> {
+                for (MouseActionListener mouseActionListener : mouseActionListeners) {
+                    mouseActionListener.onMouseReleased(mouseEvent);
+                }
+            },
+            MouseEvent.MOUSE_CLICKED, (mouseEvent, mouseActionListeners) -> {
+                for (MouseActionListener mouseActionListener : mouseActionListeners) {
+                    mouseActionListener.onMouseClicked(mouseEvent);
+                }
+            },
+            MouseEvent.MOUSE_MOVED, (mouseEvent, mouseActionListeners) -> {
+                for (MouseActionListener mouseActionListener : mouseActionListeners) {
+                    mouseActionListener.onMouseMoved(mouseEvent);
+                }
+            },
+            MouseEvent.MOUSE_DRAGGED, (mouseEvent, mouseActionListeners) -> {
+                for (MouseActionListener mouseActionListener : mouseActionListeners) {
+                    mouseActionListener.onMouseDragged(mouseEvent);
+                }
+            },
+            MouseEvent.MOUSE_ENTERED, (mouseEvent, mouseActionListeners) -> {
+                for (MouseActionListener mouseActionListener : mouseActionListeners) {
+                    mouseActionListener.onMouseEntersScreen(mouseEvent);
+                }
+            },
+            MouseEvent.MOUSE_EXITED, (mouseEvent, mouseActionListeners) -> {
+                for (MouseActionListener mouseActionListener : mouseActionListeners) {
+                    mouseActionListener.onMouseExitsScreen(mouseEvent);
+                }
+            },
+            MouseEvent.MOUSE_WHEEL, (mouseEvent, mouseActionListeners) -> {
+                for (MouseActionListener mouseActionListener : mouseActionListeners) {
+                    mouseActionListener.onMouseWheelScrolled(mouseEvent);
+                }
+            }
+    );
+
+    private static final Map<Integer, BiConsumer<KeyEvent, List<KeyboardActionListener>>> KeyboardActionProcessor = Map.of(
+            KeyEvent.KEY_PRESSED, (keyEvent, keyActionListeners) -> {
+                for (KeyboardActionListener keyboardActionListener : keyActionListeners) {
+                    keyboardActionListener.onKeyRecentlyPressed(keyEvent);
+                }
+            },
+            KeyEvent.KEY_RELEASED, (keyEvent, keyActionListeners) -> {
+                for (KeyboardActionListener keyboardActionListener : keyActionListeners) {
+                    keyboardActionListener.onKeyReleased(keyEvent);
+                }
+            },
+            KeyEvent.KEY_TYPED, (keyEvent, keyActionListeners) -> {
+                for (KeyboardActionListener keyboardActionListener : keyActionListeners) {
+                    keyboardActionListener.onKeyTyped(keyEvent);
+                }
+            }
+    );
 
     /** Constructs an {@code InputManager}, initializing its internal variables. */
     public InputManager() {
@@ -79,36 +141,12 @@ public class InputManager {
     }
 
     /**
-     * Fires a {@code key recently pressed} event to all listening {@code KeyboardActionListeners}.
+     * Fires a keyboard event to all listening {@code KeyboardActionListeners}.
      *
-     * @param e The event to be fired through to the action listener.
+     * @param keyEvent The event to be fired to the action listeners.
      */
-    public void fireKeyRecentlyPressed(KeyEvent e) {
-        for (KeyboardActionListener listener : keyActionListeners) {
-            listener.onKeyRecentlyPressed(e);
-        }
-    }
-
-    /**
-     * Fires a {@code key recently released} event to all listening {@code KeyboardActionListeners}.
-     *
-     * @param e The event to be fired through to the action listener.
-     */
-    public void fireKeyReleased(KeyEvent e) {
-        for (KeyboardActionListener listener : keyActionListeners) {
-            listener.onKeyReleased(e);
-        }
-    }
-
-    /**
-     * Fires a {@code key recently typed} event to all listening {@code KeyboardActionListeners}.
-     *
-     * @param e The event to be fired through to the action listener.
-     */
-    public void fireKeyTyped(KeyEvent e) {
-        for (KeyboardActionListener listener : keyActionListeners) {
-            listener.onKeyTyped(e);
-        }
+    public void fireKeyEvent(KeyEvent keyEvent) {
+        KeyboardActionProcessor.get(keyEvent.getID()).accept(keyEvent, keyActionListeners);
     }
 
     /**
@@ -151,91 +189,12 @@ public class InputManager {
     }
 
     /**
-     * Fires a {@code mouse button recently pressed} event to all listening {@code MouseActionListeners}.
+     * Fires a mouse event to all listening {@code MouseActionListeners}.
      *
-     * @param e The event to be fired through to the action listener.
+     * @param mouseEvent The event to be fired to the action listeners.
      */
-    public void fireMousePressed(MouseEvent e) {
-        for (MouseActionListener listener : mouseActionListeners) {
-            listener.onMousePressed(e);
-        }
-    }
-
-    /**
-     * Fires a {@code mouse button recently released} event to all listening {@code MouseActionListeners}.
-     *
-     * @param e The event to be fired through to the action listener.
-     */
-    public void fireMouseReleased(MouseEvent e) {
-        for (MouseActionListener listener : mouseActionListeners) {
-            listener.onMouseReleased(e);
-        }
-    }
-
-    /**
-     * Fires a {@code mouse button recently clicked} event to all listening {@code MouseActionListeners}.
-     *
-     * @param e The event to be fired through to the action listener.
-     */
-    public void fireMouseClicked(MouseEvent e) {
-        for (MouseActionListener listener : mouseActionListeners) {
-            listener.onMouseClicked(e);
-        }
-    }
-
-    /**
-     * Fires a {@code mouse moved} event to all listening {@code MouseActionListeners}.
-     *
-     * @param e The event to be fired through to the action listener.
-     */
-    public void fireMouseMoved(MouseEvent e) {
-        for (MouseActionListener listener : mouseActionListeners) {
-            listener.onMouseMoved(e);
-        }
-    }
-
-    /**
-     * Fires a {@code mouse dragged} event to all listening {@code MouseActionListeners}.
-     *
-     * @param e The event to be fired through to the action listener.
-     */
-    public void fireMouseDragged(MouseEvent e) {
-        for (MouseActionListener listener : mouseActionListeners) {
-            listener.onMouseDragged(e);
-        }
-    }
-
-    /**
-     * Fires a {@code mouse wheel scrolled} event to all listening {@code MouseActionListeners}.
-     *
-     * @param e The event to be fired through to the action listener.
-     */
-    public void fireMouseWheelScrolled(MouseWheelEvent e) {
-        for (MouseActionListener listener : mouseActionListeners) {
-            listener.onMouseWheelScrolled(e);
-        }
-    }
-
-    /**
-     * Fires a {@code mouse entered screen} event to all listening {@code MouseActionListeners}.
-     *
-     * @param e The event to be fired through to the action listener.
-     */
-    public void fireMouseEntered(MouseEvent e) {
-        for (MouseActionListener listener : mouseActionListeners) {
-            listener.onMouseEntersScreen(e);
-        }
-    }
-
-    /**
-     * Fires a {@code mouse exited screen} event to all listening {@code MouseActionListeners}.
-     *
-     * @param e The event to be fired through to the action listener.
-     */
-    public void fireMouseExited(MouseEvent e) {
-        for (MouseActionListener listener : mouseActionListeners) {
-            listener.onMouseExitsScreen(e);
-        }
+    public void fireMouseEvent(MouseEvent mouseEvent) {
+        MouseActionProcessor.get(mouseEvent.getID()).accept(mouseEvent, mouseActionListeners);
     }
 
     /* Received input */
@@ -275,7 +234,6 @@ public class InputManager {
                 Keyboard.processEvent(current, (KeyEvent) event);
             }
         }
-
         receivedInputEvents.clear();
 
         isProcessingEvents = false;

--- a/src/main/java/io/github/lucasstarsz/fastj/systems/input/InputManager.java
+++ b/src/main/java/io/github/lucasstarsz/fastj/systems/input/InputManager.java
@@ -29,61 +29,61 @@ public class InputManager {
     private volatile boolean isProcessingEvents;
 
     private static final Map<Integer, BiConsumer<MouseEvent, List<MouseActionListener>>> MouseActionProcessor = Map.of(
-            MouseEvent.MOUSE_PRESSED, (mouseEvent, mouseActionListeners) -> {
-                for (MouseActionListener mouseActionListener : mouseActionListeners) {
+            MouseEvent.MOUSE_PRESSED, (mouseEvent, mouseActionListenerList) -> {
+                for (MouseActionListener mouseActionListener : mouseActionListenerList) {
                     mouseActionListener.onMousePressed(mouseEvent);
                 }
             },
-            MouseEvent.MOUSE_RELEASED, (mouseEvent, mouseActionListeners) -> {
-                for (MouseActionListener mouseActionListener : mouseActionListeners) {
+            MouseEvent.MOUSE_RELEASED, (mouseEvent, mouseActionListenerList) -> {
+                for (MouseActionListener mouseActionListener : mouseActionListenerList) {
                     mouseActionListener.onMouseReleased(mouseEvent);
                 }
             },
-            MouseEvent.MOUSE_CLICKED, (mouseEvent, mouseActionListeners) -> {
-                for (MouseActionListener mouseActionListener : mouseActionListeners) {
+            MouseEvent.MOUSE_CLICKED, (mouseEvent, mouseActionListenerList) -> {
+                for (MouseActionListener mouseActionListener : mouseActionListenerList) {
                     mouseActionListener.onMouseClicked(mouseEvent);
                 }
             },
-            MouseEvent.MOUSE_MOVED, (mouseEvent, mouseActionListeners) -> {
-                for (MouseActionListener mouseActionListener : mouseActionListeners) {
+            MouseEvent.MOUSE_MOVED, (mouseEvent, mouseActionListenerList) -> {
+                for (MouseActionListener mouseActionListener : mouseActionListenerList) {
                     mouseActionListener.onMouseMoved(mouseEvent);
                 }
             },
-            MouseEvent.MOUSE_DRAGGED, (mouseEvent, mouseActionListeners) -> {
-                for (MouseActionListener mouseActionListener : mouseActionListeners) {
+            MouseEvent.MOUSE_DRAGGED, (mouseEvent, mouseActionListenerList) -> {
+                for (MouseActionListener mouseActionListener : mouseActionListenerList) {
                     mouseActionListener.onMouseDragged(mouseEvent);
                 }
             },
-            MouseEvent.MOUSE_ENTERED, (mouseEvent, mouseActionListeners) -> {
-                for (MouseActionListener mouseActionListener : mouseActionListeners) {
+            MouseEvent.MOUSE_ENTERED, (mouseEvent, mouseActionListenerList) -> {
+                for (MouseActionListener mouseActionListener : mouseActionListenerList) {
                     mouseActionListener.onMouseEntersScreen(mouseEvent);
                 }
             },
-            MouseEvent.MOUSE_EXITED, (mouseEvent, mouseActionListeners) -> {
-                for (MouseActionListener mouseActionListener : mouseActionListeners) {
+            MouseEvent.MOUSE_EXITED, (mouseEvent, mouseActionListenerList) -> {
+                for (MouseActionListener mouseActionListener : mouseActionListenerList) {
                     mouseActionListener.onMouseExitsScreen(mouseEvent);
                 }
             },
-            MouseEvent.MOUSE_WHEEL, (mouseEvent, mouseActionListeners) -> {
-                for (MouseActionListener mouseActionListener : mouseActionListeners) {
+            MouseEvent.MOUSE_WHEEL, (mouseEvent, mouseActionListenerList) -> {
+                for (MouseActionListener mouseActionListener : mouseActionListenerList) {
                     mouseActionListener.onMouseWheelScrolled(mouseEvent);
                 }
             }
     );
 
     private static final Map<Integer, BiConsumer<KeyEvent, List<KeyboardActionListener>>> KeyboardActionProcessor = Map.of(
-            KeyEvent.KEY_PRESSED, (keyEvent, keyActionListeners) -> {
-                for (KeyboardActionListener keyboardActionListener : keyActionListeners) {
+            KeyEvent.KEY_PRESSED, (keyEvent, keyActionListenerList) -> {
+                for (KeyboardActionListener keyboardActionListener : keyActionListenerList) {
                     keyboardActionListener.onKeyRecentlyPressed(keyEvent);
                 }
             },
-            KeyEvent.KEY_RELEASED, (keyEvent, keyActionListeners) -> {
-                for (KeyboardActionListener keyboardActionListener : keyActionListeners) {
+            KeyEvent.KEY_RELEASED, (keyEvent, keyActionListenerList) -> {
+                for (KeyboardActionListener keyboardActionListener : keyActionListenerList) {
                     keyboardActionListener.onKeyReleased(keyEvent);
                 }
             },
-            KeyEvent.KEY_TYPED, (keyEvent, keyActionListeners) -> {
-                for (KeyboardActionListener keyboardActionListener : keyActionListeners) {
+            KeyEvent.KEY_TYPED, (keyEvent, keyActionListenerList) -> {
+                for (KeyboardActionListener keyboardActionListener : keyActionListenerList) {
                     keyboardActionListener.onKeyTyped(keyEvent);
                 }
             }

--- a/src/main/java/io/github/lucasstarsz/fastj/systems/input/keyboard/Keyboard.java
+++ b/src/main/java/io/github/lucasstarsz/fastj/systems/input/keyboard/Keyboard.java
@@ -25,7 +25,7 @@ public class Keyboard implements KeyListener {
     private static String lastKeyPressed = "";
     private static ScheduledExecutorService keyChecker;
 
-    private static final Map<Integer, BiConsumer<Scene, KeyEvent>> keyEventProcessor = Map.of(
+    private static final Map<Integer, BiConsumer<Scene, KeyEvent>> KeyEventProcessor = Map.of(
             KeyEvent.KEY_PRESSED, (scene, keyEvent) -> {
                 KeyDescription keyDescription = KeyDescription.get(keyEvent.getKeyCode(), keyEvent.getKeyLocation());
                 Key key = null;
@@ -251,7 +251,7 @@ public class Keyboard implements KeyListener {
      * @param event   The key event to process.
      */
     public static void processEvent(Scene scene, KeyEvent event) {
-        keyEventProcessor.get(event.getID()).accept(scene, event);
+        KeyEventProcessor.get(event.getID()).accept(scene, event);
         /* Don't call the fireKeyEvent here!
          * KeyEvent.KEY_PRESSED only gets called under certain
          * conditions, so it cannot be abstracted to work here without some serious effort. */

--- a/src/main/java/io/github/lucasstarsz/fastj/systems/input/keyboard/Keyboard.java
+++ b/src/main/java/io/github/lucasstarsz/fastj/systems/input/keyboard/Keyboard.java
@@ -42,7 +42,7 @@ public class Keyboard implements KeyListener {
 
                 if (!key.currentlyPressed) {
                     key.setRecentPress(true);
-                    scene.inputManager.fireKeyRecentlyPressed(keyEvent);
+                    scene.inputManager.fireKeyEvent(keyEvent);
                 }
 
                 key.setCurrentPress(true);
@@ -57,11 +57,11 @@ public class Keyboard implements KeyListener {
                     key.setRecentRelease(true);
                 }
 
-                scene.inputManager.fireKeyReleased(keyEvent);
+                scene.inputManager.fireKeyEvent(keyEvent);
             },
             KeyEvent.KEY_TYPED, (scene, keyEvent) -> {
                 lastKeyPressed = KeyEvent.getKeyText(keyEvent.getKeyCode());
-                scene.inputManager.fireKeyTyped(keyEvent);
+                scene.inputManager.fireKeyEvent(keyEvent);
             }
     );
 
@@ -252,6 +252,9 @@ public class Keyboard implements KeyListener {
      */
     public static void processEvent(Scene scene, KeyEvent event) {
         keyEventProcessor.get(event.getID()).accept(scene, event);
+        /* Don't call the fireKeyEvent here!
+         * KeyEvent.KEY_PRESSED only gets called under certain
+         * conditions, so it cannot be abstracted to work here without some serious effort. */
     }
 
     /** Enum that defines the location of a key. */

--- a/src/main/java/io/github/lucasstarsz/fastj/systems/input/mouse/Mouse.java
+++ b/src/main/java/io/github/lucasstarsz/fastj/systems/input/mouse/Mouse.java
@@ -32,10 +32,15 @@ public class Mouse implements MouseListener, MouseMotionListener, MouseWheelList
 
     private static final ScheduledExecutorService MouseExecutor = Executors.newScheduledThreadPool(Runtime.getRuntime().availableProcessors());
     private static final Map<Integer, MouseButton> MouseButtons = new HashMap<>();
-    private static int buttonLastPressed = -1;
-    private static int buttonLastReleased = -1;
-    private static int buttonLastClicked = -1;
-    private static int lastScrollDirection = 0;
+
+    private static final int InitialMouseButton = -1;
+    private static final int InitialScrollDirection = 0;
+
+    private static int buttonLastPressed = Mouse.InitialMouseButton;
+    private static int buttonLastReleased = Mouse.InitialMouseButton;
+    private static int buttonLastClicked = Mouse.InitialMouseButton;
+    private static int lastScrollDirection = Mouse.InitialScrollDirection;
+
     private static boolean currentlyOnScreen;
     private static Pointf mouseLocation = new Pointf();
 

--- a/src/main/java/io/github/lucasstarsz/fastj/systems/input/mouse/Mouse.java
+++ b/src/main/java/io/github/lucasstarsz/fastj/systems/input/mouse/Mouse.java
@@ -52,7 +52,6 @@ public class Mouse implements MouseListener, MouseMotionListener, MouseWheelList
 
                 buttonLastPressed = mouseEvent.getButton();
                 MouseButtons.get(mouseEvent.getButton()).currentlyPressed = true;
-                scene.inputManager.fireMousePressed(mouseEvent);
             },
             MouseEvent.MOUSE_RELEASED, (scene, mouseEvent) -> {
                 if (!MouseAction.Release.recentAction) {
@@ -64,7 +63,6 @@ public class Mouse implements MouseListener, MouseMotionListener, MouseWheelList
                 }
 
                 buttonLastReleased = mouseEvent.getButton();
-                scene.inputManager.fireMouseReleased(mouseEvent);
             },
             MouseEvent.MOUSE_CLICKED, (scene, mouseEvent) -> {
                 if (!MouseAction.Click.recentAction) {
@@ -72,7 +70,6 @@ public class Mouse implements MouseListener, MouseMotionListener, MouseWheelList
                 }
 
                 buttonLastClicked = mouseEvent.getButton();
-                scene.inputManager.fireMouseClicked(mouseEvent);
             },
             MouseEvent.MOUSE_MOVED, (scene, mouseEvent) -> {
                 if (!MouseAction.Move.recentAction) {
@@ -83,8 +80,6 @@ public class Mouse implements MouseListener, MouseMotionListener, MouseWheelList
                         new Pointf(mouseEvent.getX(), mouseEvent.getY()),
                         FastJEngine.getDisplay().getResolutionScale()
                 );
-
-                scene.inputManager.fireMouseMoved(mouseEvent);
             },
             MouseEvent.MOUSE_DRAGGED, (scene, mouseEvent) -> {
                 if (!MouseAction.Drag.recentAction) {
@@ -95,8 +90,6 @@ public class Mouse implements MouseListener, MouseMotionListener, MouseWheelList
                         new Pointf(mouseEvent.getX(), mouseEvent.getY()),
                         FastJEngine.getDisplay().getResolutionScale()
                 );
-
-                scene.inputManager.fireMouseDragged(mouseEvent);
             },
             MouseEvent.MOUSE_ENTERED, (scene, mouseEvent) -> {
                 if (MouseAction.Enter.recentAction) {
@@ -104,7 +97,6 @@ public class Mouse implements MouseListener, MouseMotionListener, MouseWheelList
                 }
 
                 currentlyOnScreen = true;
-                scene.inputManager.fireMouseEntered(mouseEvent);
             },
             MouseEvent.MOUSE_EXITED, (scene, mouseEvent) -> {
                 if (MouseAction.Enter.recentAction) {
@@ -112,7 +104,6 @@ public class Mouse implements MouseListener, MouseMotionListener, MouseWheelList
                 }
 
                 currentlyOnScreen = false;
-                scene.inputManager.fireMouseExited(mouseEvent);
             },
             MouseEvent.MOUSE_WHEEL, (scene, mouseEvent) -> {
                 if (!MouseAction.WheelScroll.recentAction) {
@@ -121,7 +112,6 @@ public class Mouse implements MouseListener, MouseMotionListener, MouseWheelList
 
                 MouseWheelEvent mouseWheelEvent = (MouseWheelEvent) mouseEvent;
                 lastScrollDirection = mouseWheelEvent.getWheelRotation();
-                scene.inputManager.fireMouseWheelScrolled(mouseWheelEvent);
             }
     );
 
@@ -312,6 +302,7 @@ public class Mouse implements MouseListener, MouseMotionListener, MouseWheelList
      */
     public static void processEvent(Scene scene, MouseEvent event) {
         MouseEventProcessor.get(event.getID()).accept(scene, event);
+        scene.inputManager.fireMouseEvent(event);
     }
 
     /** Private class to store the value of a mouse button, and whether it is currently pressed. */


### PR DESCRIPTION
# Simplify the InputManager class

Fixes #11

## Additions
- Replaced use of several event-firing methods (e.g. `fireKeyReleased`, `fireKeyPressed`) with a single, multi-purpose method (e.g. `fireKeyEvent`) and a map containing the different actions to complete depending on the event type.


## Breaking Changes
See [additions](#additions) -- all event-firing methods in the `InputManager` have been removed:
  - `fireKeyPressed`
  - `fireKeyReleased`
  - `fireKeyTyped`
  - `fireMousePressed`
  - `fireMouseReleased`
  - `fireMouseClicked`
  - `fireMouseMoved`
  - `fireMouseDragged`
  - `fireMouseWheelScrolled`
  - `fireMouseEntered`
  - `fireMouseExited`

and replaced with these:
  - `fireKeyEvent`
  - `fireMouseEvent`

where each key method removed corresponds to the `fireKeyEvent` method, and each mouse method removed corresponds to the `fireMouseEvent` method.


## Other Changes
- Replaced calls to the old event fire methods in the `Mouse` class with the `fireMouseEvent` method.
