### PR TITLE
Abstract LogicManager into an Interface

### DIFF
--- a/src/example/java/io/github/lucasstarsz/fastj/example/bullethell/Main.java
+++ b/src/example/java/io/github/lucasstarsz/fastj/example/bullethell/Main.java
@@ -3,17 +3,17 @@ package io.github.lucasstarsz.fastj.example.bullethell;
 import io.github.lucasstarsz.fastj.engine.FastJEngine;
 import io.github.lucasstarsz.fastj.graphics.Display;
 
-import io.github.lucasstarsz.fastj.systems.control.LogicManager;
+import io.github.lucasstarsz.fastj.systems.control.SceneManager;
 
 import java.awt.Color;
 
 import io.github.lucasstarsz.fastj.example.bullethell.scenes.GameScene;
 import io.github.lucasstarsz.fastj.example.bullethell.scenes.LoseScene;
 
-public class Main extends LogicManager {
+public class Main extends SceneManager {
 
     @Override
-    public void setup(Display display) {
+    public void init(Display display) {
         GameScene gameScene = new GameScene();
         this.addScene(gameScene);
         this.setCurrentScene(gameScene);

--- a/src/example/java/io/github/lucasstarsz/fastj/example/bullethell/scenes/LoseScene.java
+++ b/src/example/java/io/github/lucasstarsz/fastj/example/bullethell/scenes/LoseScene.java
@@ -6,6 +6,7 @@ import io.github.lucasstarsz.fastj.graphics.Display;
 import io.github.lucasstarsz.fastj.graphics.game.Text2D;
 
 import io.github.lucasstarsz.fastj.systems.control.Scene;
+import io.github.lucasstarsz.fastj.systems.control.SceneManager;
 
 import java.awt.Color;
 import java.awt.Font;
@@ -23,7 +24,7 @@ public class LoseScene extends Scene {
 
     @Override
     public void load(Display display) {
-        GameScene gameScene = (GameScene) FastJEngine.getLogicManager().getScene(SceneNames.GameSceneName);
+        GameScene gameScene = FastJEngine.<SceneManager>getLogicManager().getScene(SceneNames.GameSceneName);
         int waveNumber = gameScene.getWaveNumber();
 
         loseText = new Text2D("You Lost...", new Pointf(300f, 375f))

--- a/src/example/java/io/github/lucasstarsz/fastj/example/bullethell/scripts/PlayerHealthBar.java
+++ b/src/example/java/io/github/lucasstarsz/fastj/example/bullethell/scripts/PlayerHealthBar.java
@@ -8,6 +8,7 @@ import io.github.lucasstarsz.fastj.graphics.game.Polygon2D;
 import io.github.lucasstarsz.fastj.graphics.game.Text2D;
 
 import io.github.lucasstarsz.fastj.systems.behaviors.Behavior;
+import io.github.lucasstarsz.fastj.systems.control.SceneManager;
 
 import java.util.Objects;
 import java.util.concurrent.Executors;
@@ -68,8 +69,9 @@ public class PlayerHealthBar implements Behavior {
 
             if (health == 0) {
                 FastJEngine.runAfterUpdate(() -> {
-                    FastJEngine.getLogicManager().switchScenes(SceneNames.LoseSceneName);
-                    FastJEngine.getLogicManager().getScene(SceneNames.GameSceneName).unload(FastJEngine.getDisplay());
+                    SceneManager sceneManager = FastJEngine.getLogicManager();
+                    sceneManager.switchScenes(SceneNames.LoseSceneName);
+                    sceneManager.getScene(SceneNames.GameSceneName).unload(FastJEngine.getDisplay());
                 });
             }
         }

--- a/src/example/java/io/github/lucasstarsz/fastj/example/helloworld/GameManager.java
+++ b/src/example/java/io/github/lucasstarsz/fastj/example/helloworld/GameManager.java
@@ -2,7 +2,7 @@ package io.github.lucasstarsz.fastj.example.helloworld;
 
 import io.github.lucasstarsz.fastj.graphics.Display;
 
-import io.github.lucasstarsz.fastj.systems.control.LogicManager;
+import io.github.lucasstarsz.fastj.systems.control.SceneManager;
 
 import java.awt.RenderingHints;
 
@@ -13,7 +13,7 @@ import io.github.lucasstarsz.fastj.example.helloworld.scenes.GameScene;
  * <p>
  * A {@code LogicManager} is used to setup scenes, display settings, etc.
  */
-public class GameManager extends LogicManager {
+public class GameManager extends SceneManager {
 
     /**
      * Sets up the game manager with the needed scenes, display settings, etc.
@@ -21,7 +21,7 @@ public class GameManager extends LogicManager {
      * @param display The {@code Display} that the game renders to.
      */
     @Override
-    public void setup(Display display) {
+    public void init(Display display) {
         /* Globally enables anti-aliasing for all objects in the game. */
         display.modifyRenderSettings(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
 

--- a/src/main/java/io/github/lucasstarsz/fastj/engine/FastJEngine.java
+++ b/src/main/java/io/github/lucasstarsz/fastj/engine/FastJEngine.java
@@ -219,6 +219,8 @@ public class FastJEngine {
     /**
      * Gets the {@link LogicManager} associated with the game engine.
      *
+     * @param <T> The type of the logic manager being retrieved. This type must match the actual type of the retrieved
+     *            logic manager, and must always extend {@link LogicManager}.
      * @return The logic manager.
      */
     @SuppressWarnings("unchecked")

--- a/src/main/java/io/github/lucasstarsz/fastj/engine/FastJEngine.java
+++ b/src/main/java/io/github/lucasstarsz/fastj/engine/FastJEngine.java
@@ -221,8 +221,9 @@ public class FastJEngine {
      *
      * @return The logic manager.
      */
-    public static LogicManager getLogicManager() {
-        return gameManager;
+    @SuppressWarnings("unchecked")
+    public static <T extends LogicManager> T getLogicManager() {
+        return (T) gameManager;
     }
 
     /**

--- a/src/main/java/io/github/lucasstarsz/fastj/engine/FastJEngine.java
+++ b/src/main/java/io/github/lucasstarsz/fastj/engine/FastJEngine.java
@@ -329,9 +329,28 @@ public class FastJEngine {
         gameLoop();
     }
 
-    /** Closes the game, without closing the JVM instance. */
+    /**
+     * Closes the game gracefully, without closing the JVM instance.
+     * <p>
+     * This method is useful for closing the game engine in normal cases, like exiting the game naturally. This should
+     * be your go-to method call for closing the game.
+     */
     public static void closeGame() {
         display.close();
+    }
+
+    /**
+     * Closes the game forcefully, without closing the JVM instance.
+     * <p>
+     * This method is useful for closing the game engine in special cases, such as if rendering has not yet started, or
+     * when a fatal error occurs that prevents the game from functioning properly. It attempts to close the game as soon
+     * as possible, without waiting for the next game update/render to be finished.
+     */
+    public static void forceCloseGame() {
+        if (display != null) {
+            display.close();
+        }
+        exit();
     }
 
     /**
@@ -355,14 +374,14 @@ public class FastJEngine {
     }
 
     /**
-     * Closes the game, then throws the error specified with the error message.
+     * Forcefully closes the game, then throws the error specified with the error message.
      *
      * @param <T>          This allows for any type of error message.
      * @param errorMessage The error message to log.
      * @param exception    The exception that caused a need for this method call.
      */
     public static <T> void error(T errorMessage, Exception exception) {
-        FastJEngine.closeGame();
+        FastJEngine.forceCloseGame();
         throw new IllegalStateException("ERROR: " + errorMessage, exception);
     }
 
@@ -452,10 +471,14 @@ public class FastJEngine {
         }
     }
 
-    /** Gracefully removes all resources created by the game engine. */
+    /** Removes all resources created by the game engine. */
     private static void exit() {
-        fpsLogger.shutdownNow();
-        gameManager.reset();
+        if (fpsLogger != null) {
+            fpsLogger.shutdownNow();
+        }
+        if (gameManager != null) {
+            gameManager.reset();
+        }
 
         Mouse.stop();
         Keyboard.stop();

--- a/src/main/java/io/github/lucasstarsz/fastj/engine/FastJEngine.java
+++ b/src/main/java/io/github/lucasstarsz/fastj/engine/FastJEngine.java
@@ -385,7 +385,7 @@ public class FastJEngine {
 
         ThreadFixer.start();
         display.init();
-        gameManager.setup(display);
+        gameManager.init(display);
 
         timer.init();
         fpsLogger.scheduleWithFixedDelay(() -> {
@@ -401,15 +401,15 @@ public class FastJEngine {
     private static void gameLoop() {
         float elapsedTime;
         float accumulator = 0f;
-        float interval = 1f / targetUPS;
+        float updateInterval = 1f / targetUPS;
 
         while (!display.isClosed()) {
             elapsedTime = timer.getElapsedTime();
             accumulator += elapsedTime;
 
-            gameManager.getCurrentScene().inputManager.processEvents(gameManager.getCurrentScene());
+            gameManager.processInputEvents();
 
-            while (accumulator >= interval) {
+            while (accumulator >= updateInterval) {
                 gameManager.update(display);
 
                 if (!AfterUpdateList.isEmpty()) {
@@ -419,7 +419,7 @@ public class FastJEngine {
                     AfterUpdateList.clear();
                 }
 
-                accumulator -= interval;
+                accumulator -= updateInterval;
             }
 
             gameManager.render(display);

--- a/src/main/java/io/github/lucasstarsz/fastj/graphics/Display.java
+++ b/src/main/java/io/github/lucasstarsz/fastj/graphics/Display.java
@@ -508,10 +508,8 @@ public class Display {
                         continue;
                     }
                     obj.render(drawGraphics);
-                } catch (NullPointerException e) {
-                    nullWarnCheck(obj, false, e);
                 } catch (Exception e) {
-                    FastJEngine.error(CrashMessages.RenderError.errorMessage + " | Origin: Game Object Drawable " + obj.getID(), e);
+                    FastJEngine.error(CrashMessages.RenderError.errorMessage + " | Origin: " + obj.getID(), e);
                     return;
                 }
             }
@@ -522,10 +520,8 @@ public class Display {
                         continue;
                     }
                     guiObj.renderAsGUIObject(drawGraphics, camera);
-                } catch (NullPointerException e) {
-                    nullWarnCheck(guiObj, true, e);
                 } catch (Exception e) {
-                    FastJEngine.error(CrashMessages.RenderError.errorMessage + " | Origin: GUI Drawable " + guiObj.getID(), e);
+                    FastJEngine.error(CrashMessages.RenderError.errorMessage + " | Origin: " + guiObj.getID(), e);
                     return;
                 }
             }
@@ -535,26 +531,6 @@ public class Display {
         } catch (IllegalStateException e) {
             if (!switchingScreenState && !FastJEngine.isRunning()) {
                 FastJEngine.error(CrashMessages.illegalAction(getClass()), e);
-            }
-        }
-    }
-
-    /**
-     * If there is a null pointer in the render method, this checks to make sure everything else in the game engine is
-     * in order before outputting a warning.
-     *
-     * @param obj           The {@code Drawable} causing the null pointer.
-     * @param isGUIDrawable Boolean that determines whether or not the {@code Drawable} is part
-     * @param e             The null pointer exception.
-     */
-    private void nullWarnCheck(Drawable obj, boolean isGUIDrawable, NullPointerException e) {
-        if (!FastJEngine.getLogicManager().isSwitchingScenes()) {
-            FastJEngine.warning("Null pointer for " + (isGUIDrawable ? "GUI" : "Game Object") + " Drawawble with id: " + obj.getID());
-            e.printStackTrace();
-            if (isGUIDrawable) {
-                FastJEngine.getLogicManager().getCurrentScene().drawableManager.refreshUIElementList();
-            } else {
-                FastJEngine.getLogicManager().getCurrentScene().drawableManager.refreshGameObjectList();
             }
         }
     }

--- a/src/main/java/io/github/lucasstarsz/fastj/graphics/Drawable.java
+++ b/src/main/java/io/github/lucasstarsz/fastj/graphics/Drawable.java
@@ -163,26 +163,8 @@ public abstract class Drawable extends TaggableEntity {
      * @return Boolean value that states whether the two {@code Drawable}s intersect.
      */
     public boolean collidesWith(Drawable obj) {
-        Area otherObject;
-        Area thisObject;
-
-        try {
-            otherObject = new Area(obj.collisionPath);
-        } catch (NullPointerException e) {
-            if (!FastJEngine.getLogicManager().isSwitchingScenes()) {
-                FastJEngine.error(CollisionErrorMessage, new NullPointerException("Collision path for Drawable with id: " + obj.id + " is null"));
-            }
-            return false;
-        }
-
-        try {
-            thisObject = new Area(collisionPath);
-        } catch (NullPointerException e) {
-            if (!FastJEngine.getLogicManager().isSwitchingScenes()) {
-                FastJEngine.error(CollisionErrorMessage, new NullPointerException("Collision path for Drawable with id: " + id + " is null"));
-            }
-            return false;
-        }
+        Area thisObject = new Area(collisionPath);
+        Area otherObject = new Area(obj.collisionPath);
 
         otherObject.intersect(thisObject);
         return !otherObject.isEmpty();

--- a/src/main/java/io/github/lucasstarsz/fastj/graphics/Drawable.java
+++ b/src/main/java/io/github/lucasstarsz/fastj/graphics/Drawable.java
@@ -24,7 +24,6 @@ import java.util.UUID;
  */
 public abstract class Drawable extends TaggableEntity {
 
-    private static final String CollisionErrorMessage = CrashMessages.theGameCrashed("a collision error.");
     private static final String GameObjectErrorMessage = CrashMessages.theGameCrashed("a game object error.");
     private static final String UiElementErrorMessage = CrashMessages.theGameCrashed("a ui element error.");
 

--- a/src/main/java/io/github/lucasstarsz/fastj/systems/control/LogicManager.java
+++ b/src/main/java/io/github/lucasstarsz/fastj/systems/control/LogicManager.java
@@ -1,355 +1,75 @@
 package io.github.lucasstarsz.fastj.systems.control;
 
-import io.github.lucasstarsz.fastj.engine.CrashMessages;
 import io.github.lucasstarsz.fastj.engine.FastJEngine;
 import io.github.lucasstarsz.fastj.graphics.Display;
 
-import java.util.Collections;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
+import io.github.lucasstarsz.fastj.systems.input.InputManager;
+import io.github.lucasstarsz.fastj.systems.input.keyboard.Keyboard;
+import io.github.lucasstarsz.fastj.systems.input.mouse.Mouse;
 
-/**
- * The manager which allows for control over the scenes in a game.
- * <p>
- * A {@code LogicManager} acts as a bridge between the internals of the engine, and the developer's code.
- *
- * @author Andrew Dey
- * @version 1.0.0
- */
-public abstract class LogicManager {
+import java.awt.event.InputEvent;
 
-    private final Map<String, Scene> scenes = new LinkedHashMap<>();
-    private Scene currentScene;
-    private boolean switchingScenes;
+public interface LogicManager {
 
     /**
-     * Set up the game scenes, the display, and everything in between.
+     * Initializes the logic manager.
      * <p>
      * This method is called after the engine has been set up, and the display has been created. As it is only called
      * once, it is the best place to set some initial settings that apply to the entire game.
      *
-     * @param display The {@code Display} that the game renders to.
+     * @param display The {@code Display} that the game renders to. Useful for applying display-related settings before
+     *                the game starts.
      */
-    public abstract void setup(Display display);
+    void init(Display display);
 
     /**
-     * Updates the current scene, its behaviors, and listeners.
+     * Allows the logic manager to process all pending input events.
      *
-     * @param display The {@code Display} that the game renders to.
+     * @see Keyboard
+     * @see Mouse
+     * @see InputManager
      */
-    public void update(Display display) {
-        updateCurrentScene(display);
-    }
+    void processInputEvents();
 
     /**
-     * Renders the current scene to the {@code Display}.
-     *
-     * @param display The {@code Display} that the game renders to.
-     */
-    public void render(Display display) {
-        renderCurrentScene(display);
-    }
-
-    /**
-     * Gets the currently active scene.
-     *
-     * @return Returns the currently active scene.
-     */
-    public Scene getCurrentScene() {
-        return currentScene;
-    }
-
-    /**
-     * Sets the current scene to the scene specified.
+     * Allows the logic manager to take in an input event.
      * <p>
-     * Instead of using this method to switch scenes, it is preferred that you use the {@code switchScene(String
-     * nextScene)} method.
+     * <b>FOR IMPLEMENTORS:</b> Input events taken in should be stored for later. When {@link #processInputEvents()} is
+     * called, it will process all the events stored here.
      *
-     * @param scene The scene which the current scene will be set to.
+     * @param inputEvent The event taken in.
      */
-    public void setCurrentScene(Scene scene) {
-        setCurrentScene(scene.getSceneName());
-    }
+    void receivedInputEvent(InputEvent inputEvent);
 
     /**
-     * Sets the current scene to the scene with the name specified.
+     * Allows the logic manager to update its game state once.
      * <p>
-     * Instead of using this method to switch scenes, it is preferred that you use the {@code switchScene(String
-     * nextScene)} method.
+     * The {@code FastJEngine} attempts to call this method at most {@code FastJEngine#targetUPS} times a second. This
+     * value can be changed using {@link FastJEngine#setTargetUPS(int)}.
      *
-     * @param sceneName The name of the scene which the current scene will be set to.
+     * @param display The {@code Display} that the game renders to. Useful for checking certain attributes of the
+     *                display while updating the game state.
      */
-    public void setCurrentScene(String sceneName) {
-        sceneExistenceCheck(sceneName);
-
-        currentScene = scenes.get(sceneName);
-        switchingScenes = !currentScene.isInitialized();
-    }
+    void update(Display display);
 
     /**
-     * Gets the list of all scenes in the logic manager.
-     *
-     * @return Returns the list of scenes in the logic manager.
-     */
-    public List<Scene> getScenes() {
-        return Collections.list(Collections.enumeration(scenes.values()));
-    }
-
-    /**
-     * Gets the scene with the specified scene name, if it exists.
-     *
-     * @param sceneName The name of the scene to retrieve.
-     * @return The scene, if it exists.
-     */
-    public Scene getScene(String sceneName) {
-        sceneExistenceCheck(sceneName);
-        return scenes.get(sceneName);
-    }
-
-    /**
-     * Gets the boolean that specifies whether the logic manager is currently switching scenes.
-     *
-     * @return Returns a boolean that specifies whether the logic manager is currently switching scenes.
-     */
-    public boolean isSwitchingScenes() {
-        return switchingScenes;
-    }
-
-    /**
-     * Adds the specified scene into the logic manager.
-     *
-     * @param scene The Scene object to be added.
-     */
-    public void addScene(Scene scene) {
-        sceneNameAlreadyExistsCheck(scene.getSceneName());
-        scenes.put(scene.getSceneName(), scene);
-    }
-
-    /**
-     * Removes the specified scene from the logic manager.
-     *
-     * @param scene The Scene object to be removed.
-     */
-    public void removeScene(Scene scene) {
-        removeScene(scene.getSceneName());
-    }
-
-    /**
-     * Removes a scene from the logic manager, based on the specified scene name.
-     *
-     * @param sceneName The name of the Scene to be removed.
-     */
-    public void removeScene(String sceneName) {
-        sceneExistenceCheck(sceneName);
-        scenes.remove(sceneName);
-    }
-
-    /**
-     * Switches to the scene specified, loading that scene if necessary.
+     * Allows the logic manager to render irs game's current state to the screen.
      * <p>
-     * This is the preferred method of switching from one scene to another. However, it does not unload the last scene.
-     * That has to be done by the user.
-     *
-     * @param nextSceneName The name of the next Scene to be loaded.
-     */
-    public void switchScenes(String nextSceneName) {
-        if (!scenes.containsKey(nextSceneName)) {
-            FastJEngine.error(CrashMessages.SceneError.errorMessage,
-                    new IllegalArgumentException("A scene with the name: \"" + nextSceneName + "\" hasn't been added!"));
-        }
-
-        switchingScenes = true;
-        Display display = FastJEngine.getDisplay();
-
-        Scene nextScene = scenes.get(nextSceneName);
-        if (!nextScene.isInitialized()) {
-            nextScene.load(display);
-            nextScene.initBehaviorListeners();
-            nextScene.setInitialized(true);
-        }
-        display.setBackgroundToCameraPos(nextScene.getCamera());
-
-        setCurrentScene(nextSceneName);
-        switchingScenes = false;
-    }
-
-    /** Loads the current scene, if it's not already initialized. */
-    public void loadCurrentScene() {
-        nullSceneCheck();
-
-        if (!currentScene.isInitialized()) {
-            currentScene.load(FastJEngine.getDisplay());
-            currentScene.initBehaviorListeners();
-
-            FastJEngine.getDisplay().setBackgroundToCameraPos(currentScene.getCamera());
-        }
-
-        currentScene.setInitialized(true);
-        switchingScenes = false;
-    }
-
-    /**
-     * Safely updates the current scene.
+     * The {@code FastJEngine} attempts to call this method at most {@code FastJEngine#targetFPS} times a second. This
+     * value can be changed using {@link FastJEngine#setTargetFPS(int)}.
      *
      * @param display The {@code Display} that the game renders to.
      */
-    private void updateCurrentScene(Display display) {
-        boolean[] snapshot = createSnapshot(display);
-
-        try {
-            nullSceneCheck();
-            initSceneCheck();
-
-            currentScene.update(display);
-            currentScene.updateBehaviorListeners();
-            currentScene.inputManager.fireKeysDown();
-
-        } catch (NullPointerException e) {
-            snapshotCheck(snapshot, e);
-        }
-    }
+    void render(Display display);
 
     /**
-     * Safely renders the current scene to the Display.
-     *
-     * @param display The {@code Display} that the game renders to.
-     */
-    private void renderCurrentScene(Display display) {
-        boolean[] snapshot = createSnapshot(display);
-
-        try {
-            nullSceneCheck();
-            initSceneCheck();
-
-            display.render(
-                    currentScene.drawableManager.getGameObjects(),
-                    currentScene.drawableManager.getUIElements(),
-                    currentScene.getCamera()
-            );
-
-        } catch (NullPointerException e) {
-            snapshotCheck(snapshot, e);
-        }
-    }
-
-    /**
-     * Creates a snapshot of the {@code switchingScenes} and {@code isSwitchingFullscreenState} booleans, to make sure
-     * the game doesn't crash out due to an attempt to call methods and other fields illegally.
-     *
-     * @param display The {@code Display} to get the fullscreen state from.
-     * @return An array of booleans to check through.
-     */
-    private boolean[] createSnapshot(Display display) {
-        return new boolean[]{
-                switchingScenes,
-                display.isSwitchingScreenState()
-        };
-    }
-
-    /**
-     * Checks if the logic manager was switching scenes.
+     * Resets the logic manager entirely.
      * <p>
-     * This method takes a boolean parameter, which is a record of whether the logic manager was switching scenes at the
-     * beginning of the parent method call.
+     * This method is called when the engine exits. Due to the game engine's mutability, it is preferred that all
+     * resources of the game engine are removed gracefully.
      * <p>
-     * If the logic manager was not switching scenes, this method will error out the game engine.
-     *
-     * @param snapshot Record of whether the logic manager was switching scenes at the beginning of the parent method
-     *                 call.
-     * @param e        The NullPointerException that would be used in the error call.
+     * <b>FOR IMPLEMENTORS:</b> By the end of this method call, the logic manager should have released all its
+     * resources.
      */
-    private void snapshotCheck(boolean[] snapshot, NullPointerException e) {
-        for (boolean b : snapshot) {
-            if (b) {
-                return;
-            }
-        }
-
-        FastJEngine.error(CrashMessages.SceneError.errorMessage, e);
-    }
-
-    /**
-     * Checks if the current scene is null.
-     * <p>
-     * If the current scene is null, this throws a NullPointerException that has a customized message, based on the
-     * context of the error.
-     */
-    private void nullSceneCheck() {
-        if (currentScene == null) {
-            throw new NullPointerException((scenes.size() < 1)
-                    ?
-                    "You haven't created a Scene yet, or you haven't added it to the list of scenes for the logic manager."
-                            + System.lineSeparator()
-                            + "To add a scene, use the addScene(Scene) method in your logic manager."
-                            + System.lineSeparator()
-                            + "Then, set the current scene to the scene you just added, using the setCurrentScene(Scene) method."
-
-                    :
-                    "A current scene hasn't been set."
-                            + System.lineSeparator()
-                            + "You should set the current scene, using the setCurrentScene(Scene) method from your logic manager."
-                            + System.lineSeparator()
-                            + "Scenes added: " + scenes.keySet().toString()
-            );
-        }
-    }
-
-    /**
-     * Checks if the current scene is initialized.
-     * <p>
-     * If the current scene isn't initialized, this throws a NullPointerException with a message that says so.
-     */
-    private void initSceneCheck() {
-        if (!currentScene.isInitialized()) {
-            throw new NullPointerException(
-                    "Current scene \"" + currentScene.getSceneName() + "\" isn't initialized."
-                            + System.lineSeparator()
-                            + "You should initialize the current scene, using the initCurrentScene(Display) method from your logic manager.");
-        }
-    }
-
-    /**
-     * Checks if the specified scene's name is already in use in the logic manager.
-     * <p>
-     * If the scene name is already in use, this method will error out the game engine.
-     *
-     * @param sceneName The scene name to check for.
-     */
-    private void sceneNameAlreadyExistsCheck(String sceneName) {
-        if (scenes.containsKey(sceneName)) {
-            IllegalArgumentException e = new IllegalArgumentException(
-                    "The scene name \"" + sceneName + "\" is already in use."
-                            + System.lineSeparator()
-                            + "Scenes added: " + scenes.keySet()
-            );
-
-            FastJEngine.error(CrashMessages.SceneError.errorMessage, e);
-        }
-    }
-
-    /**
-     * Checks if the specified scene name corresponds with a scene in the logic manager.
-     * <p>
-     * If the scene name doesn't correspond with any scenes in the logic manager, this method will error out the game
-     * engine.
-     *
-     * @param sceneName Name of the scene to be checked for.
-     */
-    private void sceneExistenceCheck(String sceneName) {
-        if (!scenes.containsKey(sceneName)) {
-            FastJEngine.error(CrashMessages.SceneError.errorMessage,
-                    new IllegalArgumentException("A scene with the name: \"" + sceneName + "\" hasn't been added!"));
-        }
-    }
-
-    /** Resets the logic manager. */
-    public void reset() {
-        for (Scene s : scenes.values()) {
-            if (s.isInitialized()) {
-                s.unload(FastJEngine.getDisplay());
-            }
-        }
-        scenes.clear();
-    }
+    void reset();
 }

--- a/src/main/java/io/github/lucasstarsz/fastj/systems/control/SceneManager.java
+++ b/src/main/java/io/github/lucasstarsz/fastj/systems/control/SceneManager.java
@@ -65,10 +65,13 @@ public abstract class SceneManager implements LogicManager {
     /**
      * Gets the currently active scene.
      *
+     * @param <T> The type of the scene being retrieved. This type must match the actual type of the retrieved scene,
+     *            and must always extend {@link Scene}.
      * @return Returns the currently active scene.
      */
-    public Scene getCurrentScene() {
-        return currentScene;
+    @SuppressWarnings("unchecked")
+    public <T extends Scene> T getCurrentScene() {
+        return (T) currentScene;
     }
 
     /**
@@ -110,6 +113,8 @@ public abstract class SceneManager implements LogicManager {
     /**
      * Gets the scene with the specified scene name, if it exists.
      *
+     * @param <T>       The type of the scene being retrieved. This type must match the actual type of the retrieved
+     *                  scene, and must always extend {@link Scene}.
      * @param sceneName The name of the scene to retrieve.
      * @return The scene, if it exists.
      */

--- a/src/main/java/io/github/lucasstarsz/fastj/systems/control/SceneManager.java
+++ b/src/main/java/io/github/lucasstarsz/fastj/systems/control/SceneManager.java
@@ -24,16 +24,6 @@ public abstract class SceneManager implements LogicManager {
     private Scene currentScene;
     private boolean switchingScenes;
 
-    /**
-     * Set up the game scenes, the display, and everything in between.
-     * <p>
-     * This method is called after the engine has been set up, and the display has been created. As it is only called
-     * once, it is the best place to set some initial settings that apply to the entire game.
-     *
-     * @param display The {@code Display} that the game renders to.
-     */
-    public abstract void init(Display display);
-
     /** Processes all pending input events. */
     public void processInputEvents() {
         currentScene.inputManager.processEvents(currentScene);

--- a/src/main/java/io/github/lucasstarsz/fastj/systems/control/SceneManager.java
+++ b/src/main/java/io/github/lucasstarsz/fastj/systems/control/SceneManager.java
@@ -123,9 +123,10 @@ public abstract class SceneManager implements LogicManager {
      * @param sceneName The name of the scene to retrieve.
      * @return The scene, if it exists.
      */
-    public Scene getScene(String sceneName) {
+    @SuppressWarnings("unchecked")
+    public <T extends Scene> T getScene(String sceneName) {
         sceneExistenceCheck(sceneName);
-        return scenes.get(sceneName);
+        return (T) scenes.get(sceneName);
     }
 
     /**

--- a/src/main/java/io/github/lucasstarsz/fastj/systems/control/SceneManager.java
+++ b/src/main/java/io/github/lucasstarsz/fastj/systems/control/SceneManager.java
@@ -1,0 +1,366 @@
+package io.github.lucasstarsz.fastj.systems.control;
+
+import io.github.lucasstarsz.fastj.engine.CrashMessages;
+import io.github.lucasstarsz.fastj.engine.FastJEngine;
+import io.github.lucasstarsz.fastj.graphics.Display;
+
+import java.awt.event.InputEvent;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * The manager which allows for control over the scenes in a game.
+ * <p>
+ * A {@code LogicManager} acts as a bridge between the internals of the engine, and the developer's code.
+ *
+ * @author Andrew Dey
+ * @version 1.0.0
+ */
+public abstract class SceneManager implements LogicManager {
+
+    private final Map<String, Scene> scenes = new LinkedHashMap<>();
+    private Scene currentScene;
+    private boolean switchingScenes;
+
+    /**
+     * Set up the game scenes, the display, and everything in between.
+     * <p>
+     * This method is called after the engine has been set up, and the display has been created. As it is only called
+     * once, it is the best place to set some initial settings that apply to the entire game.
+     *
+     * @param display The {@code Display} that the game renders to.
+     */
+    public abstract void init(Display display);
+
+    /** Processes all pending input events. */
+    public void processInputEvents() {
+        currentScene.inputManager.processEvents(currentScene);
+    }
+
+    @Override
+    public void receivedInputEvent(InputEvent inputEvent) {
+        currentScene.inputManager.receivedInputEvent(inputEvent);
+    }
+
+    /**
+     * Updates the current scene, its behaviors, and listeners.
+     *
+     * @param display The {@code Display} that the game renders to.
+     */
+    public void update(Display display) {
+        updateCurrentScene(display);
+    }
+
+    /**
+     * Renders the current scene to the {@code Display}.
+     *
+     * @param display The {@code Display} that the game renders to.
+     */
+    public void render(Display display) {
+        renderCurrentScene(display);
+    }
+
+    /** Resets the logic manager. */
+    public void reset() {
+        for (Scene s : scenes.values()) {
+            if (s.isInitialized()) {
+                s.unload(FastJEngine.getDisplay());
+            }
+        }
+        scenes.clear();
+    }
+
+    /**
+     * Gets the currently active scene.
+     *
+     * @return Returns the currently active scene.
+     */
+    public Scene getCurrentScene() {
+        return currentScene;
+    }
+
+    /**
+     * Sets the current scene to the scene specified.
+     * <p>
+     * Instead of using this method to switch scenes, it is preferred that you use the {@code switchScene(String
+     * nextScene)} method.
+     *
+     * @param scene The scene which the current scene will be set to.
+     */
+    public void setCurrentScene(Scene scene) {
+        setCurrentScene(scene.getSceneName());
+    }
+
+    /**
+     * Sets the current scene to the scene with the name specified.
+     * <p>
+     * Instead of using this method to switch scenes, it is preferred that you use the {@code switchScene(String
+     * nextScene)} method.
+     *
+     * @param sceneName The name of the scene which the current scene will be set to.
+     */
+    public void setCurrentScene(String sceneName) {
+        sceneExistenceCheck(sceneName);
+
+        currentScene = scenes.get(sceneName);
+        switchingScenes = !currentScene.isInitialized();
+    }
+
+    /**
+     * Gets the list of all scenes in the logic manager.
+     *
+     * @return Returns the list of scenes in the logic manager.
+     */
+    public List<Scene> getScenes() {
+        return Collections.list(Collections.enumeration(scenes.values()));
+    }
+
+    /**
+     * Gets the scene with the specified scene name, if it exists.
+     *
+     * @param sceneName The name of the scene to retrieve.
+     * @return The scene, if it exists.
+     */
+    public Scene getScene(String sceneName) {
+        sceneExistenceCheck(sceneName);
+        return scenes.get(sceneName);
+    }
+
+    /**
+     * Gets the boolean that specifies whether the logic manager is currently switching scenes.
+     *
+     * @return Returns a boolean that specifies whether the logic manager is currently switching scenes.
+     */
+    public boolean isSwitchingScenes() {
+        return switchingScenes;
+    }
+
+    /**
+     * Adds the specified scene into the logic manager.
+     *
+     * @param scene The Scene object to be added.
+     */
+    public void addScene(Scene scene) {
+        sceneNameAlreadyExistsCheck(scene.getSceneName());
+        scenes.put(scene.getSceneName(), scene);
+    }
+
+    /**
+     * Removes the specified scene from the logic manager.
+     *
+     * @param scene The Scene object to be removed.
+     */
+    public void removeScene(Scene scene) {
+        removeScene(scene.getSceneName());
+    }
+
+    /**
+     * Removes a scene from the logic manager, based on the specified scene name.
+     *
+     * @param sceneName The name of the Scene to be removed.
+     */
+    public void removeScene(String sceneName) {
+        sceneExistenceCheck(sceneName);
+        scenes.remove(sceneName);
+    }
+
+    /**
+     * Switches to the scene specified, loading that scene if necessary.
+     * <p>
+     * This is the preferred method of switching from one scene to another. However, it does not unload the last scene.
+     * That has to be done by the user.
+     *
+     * @param nextSceneName The name of the next Scene to be loaded.
+     */
+    public void switchScenes(String nextSceneName) {
+        if (!scenes.containsKey(nextSceneName)) {
+            FastJEngine.error(CrashMessages.SceneError.errorMessage,
+                    new IllegalArgumentException("A scene with the name: \"" + nextSceneName + "\" hasn't been added!"));
+        }
+
+        switchingScenes = true;
+        Display display = FastJEngine.getDisplay();
+
+        Scene nextScene = scenes.get(nextSceneName);
+        if (!nextScene.isInitialized()) {
+            nextScene.load(display);
+            nextScene.initBehaviorListeners();
+            nextScene.setInitialized(true);
+        }
+        display.setBackgroundToCameraPos(nextScene.getCamera());
+
+        setCurrentScene(nextSceneName);
+        switchingScenes = false;
+    }
+
+    /** Loads the current scene, if it's not already initialized. */
+    public void loadCurrentScene() {
+        nullSceneCheck();
+
+        if (!currentScene.isInitialized()) {
+            currentScene.load(FastJEngine.getDisplay());
+            currentScene.initBehaviorListeners();
+
+            FastJEngine.getDisplay().setBackgroundToCameraPos(currentScene.getCamera());
+        }
+
+        currentScene.setInitialized(true);
+        switchingScenes = false;
+    }
+
+    /**
+     * Safely updates the current scene.
+     *
+     * @param display The {@code Display} that the game renders to.
+     */
+    private void updateCurrentScene(Display display) {
+        boolean[] snapshot = createSnapshot(display);
+
+        try {
+            nullSceneCheck();
+            initSceneCheck();
+
+            currentScene.update(display);
+            currentScene.updateBehaviorListeners();
+            currentScene.inputManager.fireKeysDown();
+
+        } catch (NullPointerException e) {
+            snapshotCheck(snapshot, e);
+        }
+    }
+
+    /**
+     * Safely renders the current scene to the Display.
+     *
+     * @param display The {@code Display} that the game renders to.
+     */
+    private void renderCurrentScene(Display display) {
+        boolean[] snapshot = createSnapshot(display);
+
+        try {
+            nullSceneCheck();
+            initSceneCheck();
+
+            display.render(
+                    currentScene.drawableManager.getGameObjects(),
+                    currentScene.drawableManager.getUIElements(),
+                    currentScene.getCamera()
+            );
+
+        } catch (NullPointerException e) {
+            snapshotCheck(snapshot, e);
+        }
+    }
+
+    /**
+     * Creates a snapshot of the {@code switchingScenes} and {@code isSwitchingFullscreenState} booleans, to make sure
+     * the game doesn't crash out due to an attempt to call methods and other fields illegally.
+     *
+     * @param display The {@code Display} to get the fullscreen state from.
+     * @return An array of booleans to check through.
+     */
+    private boolean[] createSnapshot(Display display) {
+        return new boolean[]{
+                switchingScenes,
+                display.isSwitchingScreenState()
+        };
+    }
+
+    /**
+     * Checks if the logic manager was switching scenes.
+     * <p>
+     * This method takes a boolean parameter, which is a record of whether the logic manager was switching scenes at the
+     * beginning of the parent method call.
+     * <p>
+     * If the logic manager was not switching scenes, this method will error out the game engine.
+     *
+     * @param snapshot Record of whether the logic manager was switching scenes at the beginning of the parent method
+     *                 call.
+     * @param e        The NullPointerException that would be used in the error call.
+     */
+    private void snapshotCheck(boolean[] snapshot, NullPointerException e) {
+        for (boolean b : snapshot) {
+            if (b) {
+                return;
+            }
+        }
+
+        FastJEngine.error(CrashMessages.SceneError.errorMessage, e);
+    }
+
+    /**
+     * Checks if the current scene is null.
+     * <p>
+     * If the current scene is null, this throws a NullPointerException that has a customized message, based on the
+     * context of the error.
+     */
+    private void nullSceneCheck() {
+        if (currentScene == null) {
+            throw new NullPointerException((scenes.size() < 1)
+                    ?
+                    "You haven't created a Scene yet, or you haven't added it to the list of scenes for the logic manager."
+                            + System.lineSeparator()
+                            + "To add a scene, use the addScene(Scene) method in your logic manager."
+                            + System.lineSeparator()
+                            + "Then, set the current scene to the scene you just added, using the setCurrentScene(Scene) method."
+
+                    :
+                    "A current scene hasn't been set."
+                            + System.lineSeparator()
+                            + "You should set the current scene, using the setCurrentScene(Scene) method from your logic manager."
+                            + System.lineSeparator()
+                            + "Scenes added: " + scenes.keySet().toString()
+            );
+        }
+    }
+
+    /**
+     * Checks if the current scene is initialized.
+     * <p>
+     * If the current scene isn't initialized, this throws a NullPointerException with a message that says so.
+     */
+    private void initSceneCheck() {
+        if (!currentScene.isInitialized()) {
+            throw new NullPointerException(
+                    "Current scene \"" + currentScene.getSceneName() + "\" isn't initialized."
+                            + System.lineSeparator()
+                            + "You should initialize the current scene, using the initCurrentScene(Display) method from your logic manager.");
+        }
+    }
+
+    /**
+     * Checks if the specified scene's name is already in use in the logic manager.
+     * <p>
+     * If the scene name is already in use, this method will error out the game engine.
+     *
+     * @param sceneName The scene name to check for.
+     */
+    private void sceneNameAlreadyExistsCheck(String sceneName) {
+        if (scenes.containsKey(sceneName)) {
+            IllegalArgumentException e = new IllegalArgumentException(
+                    "The scene name \"" + sceneName + "\" is already in use."
+                            + System.lineSeparator()
+                            + "Scenes added: " + scenes.keySet()
+            );
+
+            FastJEngine.error(CrashMessages.SceneError.errorMessage, e);
+        }
+    }
+
+    /**
+     * Checks if the specified scene name corresponds with a scene in the logic manager.
+     * <p>
+     * If the scene name doesn't correspond with any scenes in the logic manager, this method will error out the game
+     * engine.
+     *
+     * @param sceneName Name of the scene to be checked for.
+     */
+    private void sceneExistenceCheck(String sceneName) {
+        if (!scenes.containsKey(sceneName)) {
+            FastJEngine.error(CrashMessages.SceneError.errorMessage,
+                    new IllegalArgumentException("A scene with the name: \"" + sceneName + "\" hasn't been added!"));
+        }
+    }
+}

--- a/src/main/java/io/github/lucasstarsz/fastj/systems/input/keyboard/Keyboard.java
+++ b/src/main/java/io/github/lucasstarsz/fastj/systems/input/keyboard/Keyboard.java
@@ -231,17 +231,17 @@ public class Keyboard implements KeyListener {
 
     @Override
     public void keyPressed(KeyEvent e) {
-        FastJEngine.getLogicManager().getCurrentScene().inputManager.receivedInputEvent(e);
+        FastJEngine.getLogicManager().receivedInputEvent(e);
     }
 
     @Override
     public void keyReleased(KeyEvent e) {
-        FastJEngine.getLogicManager().getCurrentScene().inputManager.receivedInputEvent(e);
+        FastJEngine.getLogicManager().receivedInputEvent(e);
     }
 
     @Override
     public void keyTyped(KeyEvent e) {
-        FastJEngine.getLogicManager().getCurrentScene().inputManager.receivedInputEvent(e);
+        FastJEngine.getLogicManager().receivedInputEvent(e);
     }
 
     /**

--- a/src/main/java/io/github/lucasstarsz/fastj/systems/input/mouse/Mouse.java
+++ b/src/main/java/io/github/lucasstarsz/fastj/systems/input/mouse/Mouse.java
@@ -261,42 +261,42 @@ public class Mouse implements MouseListener, MouseMotionListener, MouseWheelList
 
     @Override
     public void mousePressed(MouseEvent e) {
-        FastJEngine.getLogicManager().getCurrentScene().inputManager.receivedInputEvent(e);
+        FastJEngine.getLogicManager().receivedInputEvent(e);
     }
 
     @Override
     public void mouseReleased(MouseEvent e) {
-        FastJEngine.getLogicManager().getCurrentScene().inputManager.receivedInputEvent(e);
+        FastJEngine.getLogicManager().receivedInputEvent(e);
     }
 
     @Override
     public void mouseClicked(MouseEvent e) {
-        FastJEngine.getLogicManager().getCurrentScene().inputManager.receivedInputEvent(e);
+        FastJEngine.getLogicManager().receivedInputEvent(e);
     }
 
     @Override
     public void mouseMoved(MouseEvent e) {
-        FastJEngine.getLogicManager().getCurrentScene().inputManager.receivedInputEvent(e);
+        FastJEngine.getLogicManager().receivedInputEvent(e);
     }
 
     @Override
     public void mouseDragged(MouseEvent e) {
-        FastJEngine.getLogicManager().getCurrentScene().inputManager.receivedInputEvent(e);
+        FastJEngine.getLogicManager().receivedInputEvent(e);
     }
 
     @Override
     public void mouseWheelMoved(MouseWheelEvent e) {
-        FastJEngine.getLogicManager().getCurrentScene().inputManager.receivedInputEvent(e);
+        FastJEngine.getLogicManager().receivedInputEvent(e);
     }
 
     @Override
     public void mouseEntered(MouseEvent e) {
-        FastJEngine.getLogicManager().getCurrentScene().inputManager.receivedInputEvent(e);
+        FastJEngine.getLogicManager().receivedInputEvent(e);
     }
 
     @Override
     public void mouseExited(MouseEvent e) {
-        FastJEngine.getLogicManager().getCurrentScene().inputManager.receivedInputEvent(e);
+        FastJEngine.getLogicManager().receivedInputEvent(e);
     }
 
     /**

--- a/src/test/java/unittest/HeadlessHelper.java
+++ b/src/test/java/unittest/HeadlessHelper.java
@@ -32,6 +32,7 @@ public class HeadlessHelper {
             @Override
             public void load(Display display) {
                 runnable.run();
+                FastJEngine.forceCloseGame();
             }
 
             @Override
@@ -40,10 +41,7 @@ public class HeadlessHelper {
 
             @Override
             public void update(Display display) {
-                FastJEngine.closeGame();
             }
         }));
-
-        FastJEngine.run();
     }
 }

--- a/src/test/java/unittest/mock/MockManager.java
+++ b/src/test/java/unittest/mock/MockManager.java
@@ -2,10 +2,10 @@ package unittest.mock;
 
 import io.github.lucasstarsz.fastj.graphics.Display;
 
-import io.github.lucasstarsz.fastj.systems.control.LogicManager;
+import io.github.lucasstarsz.fastj.systems.control.SceneManager;
 import io.github.lucasstarsz.fastj.systems.control.Scene;
 
-public class MockManager extends LogicManager {
+public class MockManager extends SceneManager {
 
     Scene scene;
 
@@ -14,7 +14,7 @@ public class MockManager extends LogicManager {
     }
 
     @Override
-    public void setup(Display display) {
+    public void init(Display display) {
         addScene(scene);
         setCurrentScene(scene);
         loadCurrentScene();


### PR DESCRIPTION
# Abstract LogicManager into an Interface

Related to #11

## Additions
- `LogicManager` interface
- Added generics capabilities for `FastJEngine#getLogicManager`
- Added generics capabilities for `SceneManager#getScene`
- Added `FastJEngine#forceCloseGame`, which closes the game window and resets the entire game engine's state.


## Bug Fixes
- Fixed issue where some `Text2DTests` unit tests would fail to run due to a null pointer exception.
    - By calling `FastJEngine#forceCloseGame` inside the `load` method of the scene created via `runFastJWith`, we can avoid the null pointer exception from `FastJEngine#update` and having to open a window. This significantly improves the performance of all unit tests using `runFastJWith`.


## Breaking Changes
- The original `LogicManager` class has been renamed to `SceneManager`
- `SceneManager#setup` has been renamed to `SceneManager#init`


## Other Changes
- Removed special exception checks in `Display.java` due to a lack of need.
- Removed special exception checks in `Drawable.java` due to a lack of need.
- Added documentation specifying the differences between FastJEngine's `closeGame` and `forceCloseGame`.
- Added null checks to fields called in `FastJEngine#exit`.
- Changed `FastJEngine#error` to use `forceCloseGame` instead of `closeGame`.

